### PR TITLE
Link definition updates

### DIFF
--- a/cds-hooks.yaml
+++ b/cds-hooks.yaml
@@ -185,6 +185,10 @@ definitions:
 
   Link:
     type: object
+    required:
+      - label
+      - url
+      - type
     properties:
       label:
         type: string

--- a/cds-hooks.yaml
+++ b/cds-hooks.yaml
@@ -197,6 +197,9 @@ definitions:
         format: url
       type:
         type: string
+        enum:
+          - absolute
+          - smart
       appContext:
         type: string
 


### PR DESCRIPTION
Following the released  [1.0 Link specification](https://cds-hooks.hl7.org/1.0/#link), I added some details in the definition:
- Add required fields
- Restrict 'type' property to the allowed values